### PR TITLE
Use CommandVM base image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 # Files already tracked by Git are not affected.
 # See: https://git-scm.com/docs/gitignore
 
+## Intellij ##
+.idea/
+
 ## MacOS ##
 .DS_Store
 
@@ -22,5 +25,3 @@ dist
 .terraform
 .terraform.lock.hcl
 .tfvars
-
-.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ dist
 .terraform
 .terraform.lock.hcl
 .tfvars
+
+.idea/

--- a/src/packer.pkr.hcl
+++ b/src/packer.pkr.hcl
@@ -53,28 +53,21 @@ variable "skip_create_ami" {
   type        = bool
 }
 
-data "amazon-ami" "windows_server_2022" {
+data "amazon-ami" "commando-vm" {
   filters = {
-    name                = "Windows_Server-2022-English-Full-Base-*"
+    name                = "commandovm-base-*"
     root-device-type    = "ebs"
     virtualization-type = "hvm"
   }
   most_recent = true
-  owners      = ["amazon"]
+  owners      = ["780016325729"]
   region      = var.build_region
 }
 
 locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
 
-source "amazon-ebs" "windows" {
-  ami_block_device_mappings {
-    delete_on_termination = true
-    device_name           = "/dev/xvda"
-    encrypted             = true
-    volume_size           = 8
-    volume_type           = "gp3"
-  }
-  ami_name                    = "windows-server-2022-${local.timestamp}-x86_64-ebs"
+source "amazon-ebs" "commando-vm" {
+  ami_name                    = "commando-vm-${local.timestamp}-x86_64-ebs"
   ami_regions                 = var.ami_regions
   associate_public_ip_address = true
   communicator                = "winrm"
@@ -83,31 +76,30 @@ source "amazon-ebs" "windows" {
   kms_key_id                  = var.build_region_kms
   launch_block_device_mappings {
     delete_on_termination = true
-    device_name           = "/dev/xvda"
+    device_name           = "/dev/sda1"
     encrypted             = true
-    volume_size           = 8
-    volume_type           = "gp3"
+    volume_size           = 250
+    volume_type           = "gp2"
+    iops                  = 750
   }
   region             = var.build_region
   region_kms_key_ids = var.region_kms_keys
   skip_create_ami    = var.skip_create_ami
-  source_ami         = data.amazon-ami.windows_server_2022.id
+  source_ami         = data.amazon-ami.commando-vm.id
   subnet_filter {
     filters = {
       "tag:Name" = "AMI Build"
     }
   }
   tags = {
-    Application        = "Windows Server 2022"
-    Base_AMI_Name      = data.amazon-ami.windows_server_2022.name
+    Application        = "Commando VM"
+    Base_AMI_Name      = data.amazon-ami.commando-vm.name
     GitHub_Release_URL = var.release_url
     OS_Version         = "Windows Server 2022"
     Pre_Release        = var.is_prerelease
     Release            = var.release_tag
     Team               = "VM Fusion - Development"
   }
-  # Many Linux distributions are now disallowing the use of RSA keys,
-  # so it makes sense to use an ED25519 key instead.
   temporary_key_pair_type = "ed25519"
   user_data_file          = "src/winrm_bootstrap.txt"
   vpc_filter {
@@ -124,15 +116,11 @@ source "amazon-ebs" "windows" {
 
 build {
   sources = [
-    "source.amazon-ebs.windows"
+    "source.amazon-ebs.commando-vm"
   ]
-
   provisioner "powershell" {
     inline = [
-      "write-output Remove Windows Defender",
-      "Uninstall-WindowsFeature Windows-Defender",
+      "cup all",
     ]
   }
-
-  provisioner "windows-restart" {}
 }


### PR DESCRIPTION
## 🗣 Description ##
This update changes the base AMI to a Windows server 2022 VM with Commando VM preinstalled. The packer build also updates all chocolatey packages used by Commando VM.

## 💭 Motivation and context ##
The CommandoVM installation process is [not fully unattended](https://github.com/mandiant/commando-vm/blob/master/install.ps1#L398). I manually installed CommandoVM on a Windows server 2022 VM and created a base AMI from it. This allows us to use packer to automate updating the applications installed with CommandoVM.

## 🧪 Testing ##
Manually tested AMI on the INL AWS account

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.
